### PR TITLE
Generate name

### DIFF
--- a/controllers/api_controller_integration_test.go
+++ b/controllers/api_controller_integration_test.go
@@ -152,6 +152,9 @@ var _ = Describe("APIRule Controller", func() {
 						vs := vsList.Items[0]
 
 						//Meta
+						Expect(vs.Name).To(HavePrefix(apiRuleName + "-"))
+						Expect(len(vs.Name) > len(apiRuleName)).To(BeTrue())
+
 						verifyOwnerReference(vs.ObjectMeta, apiRuleName, gatewayv1alpha1.GroupVersion.String(), kind)
 						//Spec.Hosts
 						Expect(vs.Spec.Hosts).To(HaveLen(1))
@@ -219,6 +222,9 @@ var _ = Describe("APIRule Controller", func() {
 						rl := rules[expectedRuleMatchURL]
 
 						//Meta
+						Expect(rl.Name).To(HavePrefix(apiRuleName + "-"))
+						Expect(len(rl.Name) > len(apiRuleName)).To(BeTrue())
+
 						verifyOwnerReference(rl.ObjectMeta, apiRuleName, gatewayv1alpha1.GroupVersion.String(), kind)
 
 						//Spec.Upstream

--- a/controllers/api_controller_integration_test.go
+++ b/controllers/api_controller_integration_test.go
@@ -141,12 +141,16 @@ var _ = Describe("APIRule Controller", func() {
 
 						Eventually(requests, timeout).Should(Receive(Equal(expectedRequest)))
 
+						labels := make(map[string]string)
+						labels["owner"] = fmt.Sprintf("%s.%s", testName, testNamespace)
+						matchingLabelsFunc := client.MatchingLabels(labels)
+
 						//Verify VirtualService
-						expectedVSName := testName
-						expectedVSNamespace := testNamespace
-						vs := networkingv1alpha3.VirtualService{}
-						err = c.Get(context.TODO(), client.ObjectKey{Name: expectedVSName, Namespace: expectedVSNamespace}, &vs)
+						vsList := networkingv1alpha3.VirtualServiceList{}
+						err = c.List(context.TODO(), &vsList, matchingLabelsFunc)
 						Expect(err).NotTo(HaveOccurred())
+						Expect(vsList.Items).To(HaveLen(1))
+						vs := vsList.Items[0]
 
 						//Meta
 						verifyOwnerReference(vs.ObjectMeta, testName, gatewayv1alpha1.GroupVersion.String(), kind)
@@ -199,18 +203,13 @@ var _ = Describe("APIRule Controller", func() {
 
 						//Verify Rule
 						expectedRuleMatchURL := fmt.Sprintf("<http|https>://%s<%s>", testServiceHost, testPath)
-						expectedRuleNamespace := testNamespace
-
-						labels := make(map[string]string)
-						labels["owner"] = fmt.Sprintf("%s.%s", testName, expectedRuleNamespace)
-						matchingLabelsFunc := client.MatchingLabels(labels)
 
 						rlList := rulev1alpha1.RuleList{}
 
 						err = c.List(context.TODO(), &rlList, matchingLabelsFunc)
 						Expect(err).NotTo(HaveOccurred())
 
-						Expect(len(rlList.Items)).To(Equal(1))
+						Expect(rlList.Items).To(HaveLen(1))
 
 						rules := make(map[string]rulev1alpha1.Rule)
 
@@ -288,12 +287,17 @@ var _ = Describe("APIRule Controller", func() {
 						expectedRequest := reconcile.Request{NamespacedName: types.NamespacedName{Name: testName, Namespace: testNamespace}}
 
 						Eventually(requests, timeout).Should(Receive(Equal(expectedRequest)))
+
+						labels := make(map[string]string)
+						labels["owner"] = fmt.Sprintf("%s.%s", testName, testNamespace)
+						matchingLabelsFunc := client.MatchingLabels(labels)
+
 						//Verify VirtualService
-						expectedVSName := testName
-						expectedVSNamespace := testNamespace
-						vs := networkingv1alpha3.VirtualService{}
-						err = c.Get(context.TODO(), client.ObjectKey{Name: expectedVSName, Namespace: expectedVSNamespace}, &vs)
+						vsList := networkingv1alpha3.VirtualServiceList{}
+						err = c.List(context.TODO(), &vsList, matchingLabelsFunc)
 						Expect(err).NotTo(HaveOccurred())
+						Expect(vsList.Items).To(HaveLen(1))
+						vs := vsList.Items[0]
 
 						//Meta
 						verifyOwnerReference(vs.ObjectMeta, testName, gatewayv1alpha1.GroupVersion.String(), kind)
@@ -346,11 +350,6 @@ var _ = Describe("APIRule Controller", func() {
 
 						//Verify Rule1
 						expectedRuleMatchURL := fmt.Sprintf("<http|https>://%s<%s>", testServiceHost, "/img")
-						expectedRuleNamespace := testNamespace
-
-						labels := make(map[string]string)
-						labels["owner"] = fmt.Sprintf("%s.%s", testName, expectedRuleNamespace)
-						matchingLabelsFunc := client.MatchingLabels(labels)
 
 						rlList := rulev1alpha1.RuleList{}
 
@@ -506,10 +505,16 @@ var _ = Describe("APIRule Controller", func() {
 						expectedRequest := reconcile.Request{NamespacedName: types.NamespacedName{Name: testName, Namespace: testNamespace}}
 						Eventually(requests, timeout).Should(Receive(Equal(expectedRequest)))
 
+						labels := make(map[string]string)
+						labels["owner"] = fmt.Sprintf("%s.%s", testName, testNamespace)
+						matchingLabelsFunc := client.MatchingLabels(labels)
+
 						//Verify VirtualService
-						vs := networkingv1alpha3.VirtualService{}
-						err = c.Get(context.TODO(), client.ObjectKey{Name: fmt.Sprintf("%s", testName), Namespace: testNamespace}, &vs)
+						vsList := networkingv1alpha3.VirtualServiceList{}
+						err = c.List(context.TODO(), &vsList, matchingLabelsFunc)
 						Expect(err).NotTo(HaveOccurred())
+						Expect(vsList.Items).To(HaveLen(1))
+						vs := vsList.Items[0]
 
 						//Meta
 						verifyOwnerReference(vs.ObjectMeta, testName, gatewayv1alpha1.GroupVersion.String(), kind)
@@ -587,10 +592,6 @@ var _ = Describe("APIRule Controller", func() {
 							{path: "status", handler: "noop", config: nil},
 						} {
 							expectedRuleMatchURL := fmt.Sprintf("<http|https>://%s</%s>", testServiceHost, tc.path)
-
-							labels := make(map[string]string)
-							labels["owner"] = fmt.Sprintf("%s.%s", testName, testNamespace)
-							matchingLabelsFunc := client.MatchingLabels(labels)
 
 							rlList := rulev1alpha1.RuleList{}
 

--- a/internal/builders/access_rule.go
+++ b/internal/builders/access_rule.go
@@ -26,6 +26,12 @@ func (ar *accessRule) Name(val string) *accessRule {
 	return ar
 }
 
+func (ar *accessRule) GenerateName(val string) *accessRule {
+	ar.value.Name = ""
+	ar.value.GenerateName = val
+	return ar
+}
+
 func (ar *accessRule) Namespace(val string) *accessRule {
 	ar.value.Namespace = val
 	return ar

--- a/internal/builders/access_rule_test.go
+++ b/internal/builders/access_rule_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Builder for", func() {
 				Raw: requiredScopesJSON,
 			}
 
-			ar := AccessRule().Name(name).Namespace(namespace).
+			ar := AccessRule().GenerateName(name).Namespace(namespace).
 				Owner(OwnerReference().Name(refName).APIVersion(refVersion).Kind(refKind).UID(refUID).Controller(true)).
 				Spec(AccessRuleSpec().
 					Upstream(Upstream().
@@ -64,7 +64,8 @@ var _ = Describe("Builder for", func() {
 						Handler(Handler().
 							Name("hydrator")))).
 				Get()
-			Expect(ar.Name).To(Equal(name))
+			Expect(ar.Name).To(BeEmpty())
+			Expect(ar.GenerateName).To(Equal(name))
 			Expect(ar.Namespace).To(Equal(namespace))
 			Expect(ar.OwnerReferences).To(HaveLen(1))
 			Expect(ar.OwnerReferences[0].Name).To(Equal(refName))

--- a/internal/builders/virtual_service.go
+++ b/internal/builders/virtual_service.go
@@ -30,6 +30,12 @@ func (vs *virtualService) Name(val string) *virtualService {
 	return vs
 }
 
+func (vs *virtualService) GenerateName(val string) *virtualService {
+	vs.value.Name = ""
+	vs.value.GenerateName = val
+	return vs
+}
+
 func (vs *virtualService) Namespace(val string) *virtualService {
 	vs.value.Namespace = val
 	return vs

--- a/internal/builders/virtual_service_test.go
+++ b/internal/builders/virtual_service_test.go
@@ -30,14 +30,15 @@ var _ = Describe("Builder for", func() {
 			initialVs.Name = "shoudBeOverwritten"
 			initialVs.Spec.Hosts = []string{"a,", "b", "c"}
 
-			vs := VirtualService().From(&initialVs).Name(name).Namespace(namespace).
+			vs := VirtualService().From(&initialVs).GenerateName(name).Namespace(namespace).
 				Owner(OwnerReference().Name(refName).APIVersion(refVersion).Kind(refKind).UID(refUID).Controller(true)).
 				Spec(
 					VirtualServiceSpec().
 						Host(host).
 						Gateway(gateway)).
 				Get()
-			Expect(vs.Name).To(Equal(name))
+			Expect(vs.Name).To(BeEmpty())
+			Expect(vs.GenerateName).To(Equal(name))
 			Expect(vs.Namespace).To(Equal(namespace))
 			Expect(vs.OwnerReferences).To(HaveLen(1))
 			Expect(vs.OwnerReferences[0].Name).To(Equal(refName))

--- a/internal/processing/helpers.go
+++ b/internal/processing/helpers.go
@@ -2,8 +2,6 @@ package processing
 
 import (
 	"fmt"
-	"math/rand"
-	"time"
 
 	gatewayv1alpha1 "github.com/kyma-incubator/api-gateway/api/v1alpha1"
 	"github.com/kyma-incubator/api-gateway/internal/builders"
@@ -16,13 +14,12 @@ func modifyAccessRule(existing, required *rulev1alpha1.Rule) {
 }
 
 func generateAccessRule(api *gatewayv1alpha1.APIRule, rule gatewayv1alpha1.Rule, accessStrategies []*rulev1alpha1.Authenticator) *rulev1alpha1.Rule {
-	rand.Seed(time.Now().UTC().UnixNano())
-	name := fmt.Sprintf("%s-%d", api.ObjectMeta.Name, rand.Int())
+	namePrefix := fmt.Sprintf("%s-", api.ObjectMeta.Name)
 	namespace := api.ObjectMeta.Namespace
 	ownerRef := generateOwnerRef(api)
 
 	return builders.AccessRule().
-		Name(name).
+		GenerateName(namePrefix).
 		Namespace(namespace).
 		Owner(builders.OwnerReference().From(&ownerRef)).
 		Spec(builders.AccessRuleSpec().From(generateAccessRuleSpec(api, rule, accessStrategies))).

--- a/internal/processing/processing.go
+++ b/internal/processing/processing.go
@@ -3,6 +3,7 @@ package processing
 import (
 	"context"
 	"fmt"
+
 	"github.com/kyma-incubator/api-gateway/internal/builders"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -188,7 +189,7 @@ func (f *Factory) updateVirtualService(existing, required *networkingv1alpha3.Vi
 }
 
 func (f *Factory) generateVirtualService(api *gatewayv1alpha1.APIRule) *networkingv1alpha3.VirtualService {
-	virtualServiceName := fmt.Sprintf("%s", api.ObjectMeta.Name)
+	virtualServiceNamePrefix := fmt.Sprintf("%s-", api.ObjectMeta.Name)
 	ownerRef := generateOwnerRef(api)
 
 	vsSpecBuilder := builders.VirtualServiceSpec()
@@ -210,7 +211,7 @@ func (f *Factory) generateVirtualService(api *gatewayv1alpha1.APIRule) *networki
 	}
 
 	vsBuilder := builders.VirtualService().
-		Name(virtualServiceName).
+		GenerateName(virtualServiceNamePrefix).
 		Namespace(api.ObjectMeta.Namespace).
 		Owner(builders.OwnerReference().From(&ownerRef)).
 		Label("owner", fmt.Sprintf("%s.%s", api.ObjectMeta.Name, api.ObjectMeta.Namespace))

--- a/internal/processing/processing_test.go
+++ b/internal/processing/processing_test.go
@@ -102,7 +102,8 @@ func TestCreateVS_NoOp(t *testing.T) {
 	assert.Equal(vs.Spec.HTTP[0].Route[0].Destination.Port.Number, servicePort)
 	assert.Equal(vs.Spec.HTTP[0].Match[0].URI.Regex, apiRule.Spec.Rules[0].Path)
 
-	assert.Equal(vs.ObjectMeta.Name, apiName)
+	assert.Equal(vs.ObjectMeta.Name, "")
+	assert.Equal(vs.ObjectMeta.GenerateName, apiName+"-")
 	assert.Equal(vs.ObjectMeta.Namespace, apiNamespace)
 
 	assert.Equal(vs.ObjectMeta.OwnerReferences[0].APIVersion, apiAPIVersion)
@@ -151,7 +152,8 @@ func TestCreateVS_JWT(t *testing.T) {
 	assert.Equal(vs.Spec.HTTP[0].Route[0].Destination.Port.Number, uint32(4455))
 	assert.Equal(vs.Spec.HTTP[0].Match[0].URI.Regex, apiRule.Spec.Rules[0].Path)
 
-	assert.Equal(vs.ObjectMeta.Name, apiName)
+	assert.Equal(vs.ObjectMeta.Name, "")
+	assert.Equal(vs.ObjectMeta.GenerateName, apiName+"-")
 	assert.Equal(vs.ObjectMeta.Namespace, apiNamespace)
 
 	assert.Equal(vs.ObjectMeta.OwnerReferences[0].APIVersion, apiAPIVersion)
@@ -199,7 +201,8 @@ func TestGenerateAR_JWT(t *testing.T) {
 
 	assert.Equal(ar.Spec.Upstream.URL, "http://example-service.some-namespace.svc.cluster.local:8080")
 
-	assert.Contains(ar.ObjectMeta.Name, apiName)
+	assert.Contains(ar.ObjectMeta.Name, "")
+	assert.Contains(ar.ObjectMeta.GenerateName, apiName+"-")
 	assert.Equal(ar.ObjectMeta.Namespace, apiNamespace)
 
 	assert.Equal(ar.ObjectMeta.OwnerReferences[0].APIVersion, apiAPIVersion)
@@ -245,7 +248,8 @@ func TestGenerateVS_OAUTH(t *testing.T) {
 	assert.Equal(vs.Spec.HTTP[0].Route[0].Destination.Port.Number, uint32(4455))
 	assert.Equal(vs.Spec.HTTP[0].Match[0].URI.Regex, apiPath)
 
-	assert.Equal(vs.ObjectMeta.Name, apiName)
+	assert.Equal(vs.ObjectMeta.Name, "")
+	assert.Equal(vs.ObjectMeta.GenerateName, apiName+"-")
 	assert.Equal(vs.ObjectMeta.Namespace, apiNamespace)
 
 	assert.Equal(vs.ObjectMeta.OwnerReferences[0].APIVersion, apiAPIVersion)
@@ -292,7 +296,8 @@ func TestGenerateAR_OAUTH(t *testing.T) {
 
 	assert.Equal(ar.Spec.Upstream.URL, "http://example-service.some-namespace.svc.cluster.local:8080")
 
-	assert.Contains(ar.ObjectMeta.Name, apiName)
+	assert.Contains(ar.ObjectMeta.Name, "")
+	assert.Contains(ar.ObjectMeta.GenerateName, apiName+"-")
 	assert.Equal(ar.ObjectMeta.Namespace, apiNamespace)
 
 	assert.Equal(ar.ObjectMeta.OwnerReferences[0].APIVersion, apiAPIVersion)

--- a/internal/processing/processing_test.go
+++ b/internal/processing/processing_test.go
@@ -102,7 +102,7 @@ func TestCreateVS_NoOp(t *testing.T) {
 	assert.Equal(vs.Spec.HTTP[0].Route[0].Destination.Port.Number, servicePort)
 	assert.Equal(vs.Spec.HTTP[0].Match[0].URI.Regex, apiRule.Spec.Rules[0].Path)
 
-	assert.Equal(vs.ObjectMeta.Name, "")
+	assert.Empty(vs.ObjectMeta.Name)
 	assert.Equal(vs.ObjectMeta.GenerateName, apiName+"-")
 	assert.Equal(vs.ObjectMeta.Namespace, apiNamespace)
 
@@ -152,7 +152,7 @@ func TestCreateVS_JWT(t *testing.T) {
 	assert.Equal(vs.Spec.HTTP[0].Route[0].Destination.Port.Number, uint32(4455))
 	assert.Equal(vs.Spec.HTTP[0].Match[0].URI.Regex, apiRule.Spec.Rules[0].Path)
 
-	assert.Equal(vs.ObjectMeta.Name, "")
+	assert.Empty(vs.ObjectMeta.Name)
 	assert.Equal(vs.ObjectMeta.GenerateName, apiName+"-")
 	assert.Equal(vs.ObjectMeta.Namespace, apiNamespace)
 
@@ -201,8 +201,8 @@ func TestGenerateAR_JWT(t *testing.T) {
 
 	assert.Equal(ar.Spec.Upstream.URL, "http://example-service.some-namespace.svc.cluster.local:8080")
 
-	assert.Contains(ar.ObjectMeta.Name, "")
-	assert.Contains(ar.ObjectMeta.GenerateName, apiName+"-")
+	assert.Empty(ar.ObjectMeta.Name)
+	assert.Equal(ar.ObjectMeta.GenerateName, apiName+"-")
 	assert.Equal(ar.ObjectMeta.Namespace, apiNamespace)
 
 	assert.Equal(ar.ObjectMeta.OwnerReferences[0].APIVersion, apiAPIVersion)
@@ -248,7 +248,7 @@ func TestGenerateVS_OAUTH(t *testing.T) {
 	assert.Equal(vs.Spec.HTTP[0].Route[0].Destination.Port.Number, uint32(4455))
 	assert.Equal(vs.Spec.HTTP[0].Match[0].URI.Regex, apiPath)
 
-	assert.Equal(vs.ObjectMeta.Name, "")
+	assert.Empty(vs.ObjectMeta.Name)
 	assert.Equal(vs.ObjectMeta.GenerateName, apiName+"-")
 	assert.Equal(vs.ObjectMeta.Namespace, apiNamespace)
 
@@ -296,8 +296,8 @@ func TestGenerateAR_OAUTH(t *testing.T) {
 
 	assert.Equal(ar.Spec.Upstream.URL, "http://example-service.some-namespace.svc.cluster.local:8080")
 
-	assert.Contains(ar.ObjectMeta.Name, "")
-	assert.Contains(ar.ObjectMeta.GenerateName, apiName+"-")
+	assert.Empty(ar.ObjectMeta.Name)
+	assert.Equal(ar.ObjectMeta.GenerateName, apiName+"-")
 	assert.Equal(ar.ObjectMeta.Namespace, apiNamespace)
 
 	assert.Equal(ar.ObjectMeta.OwnerReferences[0].APIVersion, apiAPIVersion)


### PR DESCRIPTION
**Description**

Use `ObjectMeta.GenerateName` feature to automatically generate name suffix for Rules and VirtualServices created by the controller

Changes proposed in this pull request:

- Use auto-generated name suffix for Rules and VirtualServices
- Update tests

**Related issue(s)**
Implements #63 