### PR TITLE
Require rules field in APIRule CRD

### DIFF
--- a/api/v1alpha1/apiRule_types.go
+++ b/api/v1alpha1/apiRule_types.go
@@ -39,9 +39,9 @@ type APIRuleSpec struct {
 	// Gateway to be used
 	// +kubebuilder:validation:Pattern=^(?:[_a-z0-9](?:[_a-z0-9-]+[a-z0-9])?\.)+(?:[a-z](?:[a-z0-9-]+[a-z0-9])?)?$
 	Gateway *string `json:"gateway"`
-	//Paths represents collection of Path to secure
+	//Rules represents collection of Rule to secure
 	// +kubebuilder:validation:MinItems=1
-	Rules []Rule `json:"rules,omitempty"`
+	Rules []Rule `json:"rules"`
 }
 
 // APIRuleStatus defines the observed state of ApiRule

--- a/api/v1alpha1/apiRule_types.go
+++ b/api/v1alpha1/apiRule_types.go
@@ -39,7 +39,7 @@ type APIRuleSpec struct {
 	// Gateway to be used
 	// +kubebuilder:validation:Pattern=^(?:[_a-z0-9](?:[_a-z0-9-]+[a-z0-9])?\.)+(?:[a-z](?:[a-z0-9-]+[a-z0-9])?)?$
 	Gateway *string `json:"gateway"`
-	//Rules represents collection of Rule to secure
+	//Rules represents collection of Rule to apply
 	// +kubebuilder:validation:MinItems=1
 	Rules []Rule `json:"rules"`
 }

--- a/config/crd/bases/gateway.kyma-project.io_apirules.yaml
+++ b/config/crd/bases/gateway.kyma-project.io_apirules.yaml
@@ -392,7 +392,7 @@ spec:
               pattern: ^(?:[_a-z0-9](?:[_a-z0-9-]+[a-z0-9])?\.)+(?:[a-z](?:[a-z0-9-]+[a-z0-9])?)?$
               type: string
             rules:
-              description: Rules represents collection of Rule to secure
+              description: Rules represents collection of Rule to apply
               items:
                 properties:
                   accessStrategies:

--- a/config/crd/bases/gateway.kyma-project.io_apirules.yaml
+++ b/config/crd/bases/gateway.kyma-project.io_apirules.yaml
@@ -392,7 +392,7 @@ spec:
               pattern: ^(?:[_a-z0-9](?:[_a-z0-9-]+[a-z0-9])?\.)+(?:[a-z](?:[a-z0-9-]+[a-z0-9])?)?$
               type: string
             rules:
-              description: Paths represents collection of Path to secure
+              description: Rules represents collection of Rule to secure
               items:
                 properties:
                   accessStrategies:
@@ -471,6 +471,7 @@ spec:
           required:
           - service
           - gateway
+          - rules
           type: object
         status:
           properties:

--- a/install/helm/api-gateway/files/crd-apirules.yaml
+++ b/install/helm/api-gateway/files/crd-apirules.yaml
@@ -392,7 +392,7 @@ spec:
               pattern: ^(?:[_a-z0-9](?:[_a-z0-9-]+[a-z0-9])?\.)+(?:[a-z](?:[a-z0-9-]+[a-z0-9])?)?$
               type: string
             rules:
-              description: Paths represents collection of Path to secure
+              description: Rules represents collection of Rule to apply
               items:
                 properties:
                   accessStrategies:
@@ -471,6 +471,7 @@ spec:
           required:
             - service
             - gateway
+            - rules
           type: object
         status:
           properties:

--- a/install/k8s/apiextensions.k8s.io_v1beta1_customresourcedefinition_apirules.gateway.kyma-project.io.yaml
+++ b/install/k8s/apiextensions.k8s.io_v1beta1_customresourcedefinition_apirules.gateway.kyma-project.io.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/install/k8s/apiextensions.k8s.io_v1beta1_customresourcedefinition_apirules.gateway.kyma-project.io.yaml
+++ b/install/k8s/apiextensions.k8s.io_v1beta1_customresourcedefinition_apirules.gateway.kyma-project.io.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -131,7 +133,7 @@ spec:
                           this object.
                         type: string
                     required:
-                    - name
+                      - name
                     type: object
                   type: array
                 result:
@@ -263,7 +265,7 @@ spec:
                       type: string
                   type: object
               required:
-              - pending
+                - pending
               type: object
             labels:
               additionalProperties:
@@ -356,10 +358,10 @@ spec:
                     description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
                     type: string
                 required:
-                - apiVersion
-                - kind
-                - name
-                - uid
+                  - apiVersion
+                  - kind
+                  - name
+                  - uid
                 type: object
               type: array
             resourceVersion:
@@ -390,7 +392,7 @@ spec:
               pattern: ^(?:[_a-z0-9](?:[_a-z0-9-]+[a-z0-9])?\.)+(?:[a-z](?:[a-z0-9-]+[a-z0-9])?)?$
               type: string
             rules:
-              description: Paths represents collection of Path to secure
+              description: Rules represents collection of Rule to apply
               items:
                 properties:
                   accessStrategies:
@@ -405,7 +407,7 @@ spec:
                           description: Name is the name of a handler
                           type: string
                       required:
-                      - handler
+                        - handler
                       type: object
                     minItems: 1
                     type: array
@@ -426,7 +428,7 @@ spec:
                           description: Name is the name of a handler
                           type: string
                       required:
-                      - handler
+                        - handler
                       type: object
                     type: array
                   path:
@@ -434,8 +436,8 @@ spec:
                     pattern: ^/([0-9a-zA-Z./*]+)
                     type: string
                 required:
-                - path
-                - accessStrategies
+                  - path
+                  - accessStrategies
                 type: object
               minItems: 1
               type: array
@@ -462,13 +464,14 @@ spec:
                   minimum: 1
                   type: integer
               required:
-              - name
-              - port
-              - host
+                - name
+                - port
+                - host
               type: object
           required:
-          - service
-          - gateway
+            - service
+            - gateway
+            - rules
           type: object
         status:
           properties:
@@ -502,9 +505,9 @@ spec:
           type: object
       type: object
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+    - name: v1alpha1
+      served: true
+      storage: true
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
**Description**

Documentation already states that `spec.rules` field is required.

Changes proposed in this pull request:

- Remove omitempty from Rules field in APIRuleSpec

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/6337