### PR TITLE
Change alpine-kubectl imager to k8s-tools

### DIFF
--- a/install/helm/api-gateway/values.yaml
+++ b/install/helm/api-gateway/values.yaml
@@ -2,8 +2,8 @@ replicaCount: 1
 
 rbacJob:
   image:
-    repository: eu.gcr.io/kyma-project/test-infra/alpine-kubectl
-    tag: "v20190325-ff66a3a"
+    repository: eu.gcr.io/kyma-project/tpi/k8s-tools
+    tag: "20210504-12243229"
 
 image:
   repository: eu.gcr.io/kyma-project/incubator/develop/api-gateway-controller


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Image `eu.gcr.io/kyma-project/test-infra/alpine-kubectl` is deprecated and removed from the test-infra repo. This PR changes image `eu.gcr.io/kyma-project/test-infra/alpine-kubectl` to `eu.gcr.io/kyma-project/tpi/k8s-tools:20210504-12243229`.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/test-infra/issues/3647